### PR TITLE
Corrects URL references for the dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a demostration of the integration of [AutowareAI](https://gitlab.com/aut
 # Installing requirements
 * This demo works on Ubuntu 18.04 with CUDA 10.2 (you need an NVIDIA graphics card).
 * Install NVIDIA drivers and verify the drivers with: `nvidia-smi`
-* Install Docker: `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/install-docker.sh | bash`
-* Install the NVIDIA Container Toolkit: `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/install-nvidia-docker.sh | bash`
-* Install [ADE](https://www.apex.ai/post/ade-ensuring-that-all-developers-in-a-project-have-a-common-consistent-development-environment): `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/install-ade.sh | bash`
+* Install Docker: `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/ubuntu/bionic/install-docker.sh | bash`
+* Install the NVIDIA Container Toolkit: `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/nvidia/docker/install-nvidia-docker.sh | bash`
+* Install [ADE](https://www.apex.ai/post/ade-ensuring-that-all-developers-in-a-project-have-a-common-consistent-development-environment): `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/development/install-ade.sh | bash`
 
 # Getting Started
 * Create your workspace directory (you can choose your own name or use an existing folder): `mkdir adehome`


### PR DESCRIPTION
I replaced the URLs with what I figured was the new location for that shell script in the GitLab repo and tested it in a VM to make sure it works. Please review and let me know what you think!