### PR TITLE
Add support for most Linux distributions in installing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,139 @@
+# Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+
+DOCKER ?= docker
+MKDIR  ?= mkdir
+DIST_DIR ?= $(CURDIR)/dist
+
+LIB_NAME := nvidia-docker2
+LIB_VERSION := 2.6.0
+PKG_REV := 1
+
+RUNTIME_VERSION := 3.5.0
+
+# Supported OSs by architecture
+AMD64_TARGETS := ubuntu18.04 
+
+# By default run all native docker-based targets
+docker-native:
+
+# Define top-level build targets
+docker%: SHELL:=/bin/bash
+
+# Native targets
+PLATFORM ?= $(shell uname -m)
+ifeq ($(PLATFORM),x86_64)
+NATIVE_TARGETS := $(AMD64_TARGETS) $(X86_64_TARGETS)
+$(AMD64_TARGETS): %: %-amd64
+$(X86_64_TARGETS): %: %-x86_64
+else ifeq ($(PLATFORM),ppc64le)
+NATIVE_TARGETS := $(PPC64LE_TARGETS)
+$(PPC64LE_TARGETS): %: %-ppc64le
+else ifeq ($(PLATFORM),aarch64)
+NATIVE_TARGETS := $(ARM64_TARGETS) $(AARCH64_TARGETS)
+$(ARM64_TARGETS): %: %-arm64
+$(AARCH64_TARGETS): %: %-aarch64
+endif
+docker-native: $(NATIVE_TARGETS)
+
+# amd64 targets
+AMD64_TARGETS := $(patsubst %, %-amd64, $(AMD64_TARGETS))
+$(AMD64_TARGETS): ARCH := amd64
+$(AMD64_TARGETS): %: --%
+docker-amd64: $(AMD64_TARGETS)
+
+# x86_64 targets
+X86_64_TARGETS := $(patsubst %, %-x86_64, $(X86_64_TARGETS))
+$(X86_64_TARGETS): ARCH := x86_64
+$(X86_64_TARGETS): %: --%
+docker-x86_64: $(X86_64_TARGETS)
+
+# arm64 targets
+ARM64_TARGETS := $(patsubst %, %-arm64, $(ARM64_TARGETS))
+$(ARM64_TARGETS): ARCH := arm64
+$(ARM64_TARGETS): %: --%
+docker-arm64: $(ARM64_TARGETS)
+
+# aarch64 targets
+AARCH64_TARGETS := $(patsubst %, %-aarch64, $(AARCH64_TARGETS))
+$(AARCH64_TARGETS): ARCH := aarch64
+$(AARCH64_TARGETS): %: --%
+docker-aarch64: $(AARCH64_TARGETS)
+
+# ppc64le targets
+PPC64LE_TARGETS := $(patsubst %, %-ppc64le, $(PPC64LE_TARGETS))
+$(PPC64LE_TARGETS): ARCH := ppc64le
+$(PPC64LE_TARGETS): WITH_LIBELF := yes
+$(PPC64LE_TARGETS): %: --%
+docker-ppc64le: $(PPC64LE_TARGETS)
+
+# docker target to build for all os/arch combinations
+docker-all: $(AMD64_TARGETS) $(X86_64_TARGETS) \
+            $(ARM64_TARGETS) $(AARCH64_TARGETS) \
+            $(PPC64LE_TARGETS)
+
+# Default variables for all private '--' targets below.
+# One private target is defined for each OS we support.
+--%: TARGET_PLATFORM = $(*)
+--%: VERSION = $(patsubst $(OS)%-$(ARCH),%,$(TARGET_PLATFORM))
+--%: BASEIMAGE = $(OS):$(VERSION)
+--%: BUILDIMAGE = nvidia/$(LIB_NAME)/$(OS)$(VERSION)-$(ARCH)
+--%: DOCKERFILE = $(CURDIR)/docker/Dockerfile.$(OS)
+--%: ARTIFACTS_DIR = $(DIST_DIR)/$(OS)$(VERSION)/$(ARCH)
+--%: docker-build-%
+	@
+
+# private ubuntu target
+--ubuntu%: OS := ubuntu
+--ubuntu%: DOCKER_VERSION := docker-ce (>= 18.06.0~ce~3-0~ubuntu) | docker-ee (>= 18.06.0~ce~3-0~ubuntu) | docker.io (>= 18.06.0)
+
+# private debian target
+--debian%: OS := debian
+--debian%: DOCKER_VERSION := docker-ce (>= 18.06.0~ce~3-0~debian) | docker-ee (>= 18.06.0~ce~3-0~debian) | docker.io (>= 18.06.0)
+
+# private centos target
+--centos%: OS := centos
+--centos%: DOCKER_VERSION := docker-ce >= 18.06.3.ce-3.el7
+
+# private amazonlinuxtarget
+--amazonlinux%: OS := amazonlinux
+--amazonlinux2%: DOCKER_VERSION := docker >= 18.06.1ce-2.amzn2
+--amazonlinux1%: DOCKER_VERSION := docker >= 18.06.1ce-2.16.amzn1
+
+# private opensuse-leap target
+--opensuse-leap%: OS := opensuse-leap
+--opensuse-leap%: BASEIMAGE = opensuse/leap:$(VERSION)
+--opensuse-leap%: DOCKER_VERSION := docker >= 18.09.1_ce
+
+# private rhel target (actually built on centos)
+--rhel%: OS := centos
+--rhel%: VERSION = $(patsubst rhel%-$(ARCH),%,$(TARGET_PLATFORM))
+--rhel%: ARTIFACTS_DIR = $(DIST_DIR)/rhel$(VERSION)/$(ARCH)
+--rhel%: DOCKER_VERSION := docker-ce >= 18.06.3.ce-3.el7
+
+docker-build-%:
+	@echo "Building for $(TARGET_PLATFORM)"
+	docker pull --platform=linux/$(ARCH) $(BASEIMAGE)
+	DOCKER_BUILDKIT=1 \
+	$(DOCKER) build \
+	    --progress=plain \
+	    --build-arg BASEIMAGE="$(BASEIMAGE)" \
+	    --build-arg DOCKER_VERSION="$(DOCKER_VERSION)" \
+	    --build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)" \
+	    --build-arg PKG_VERS="$(LIB_VERSION)" \
+	    --build-arg PKG_REV="$(PKG_REV)" \
+	    --tag $(BUILDIMAGE) \
+	    --file $(DOCKERFILE) .
+	$(DOCKER) run \
+	    -e DISTRIB \
+	    -e SECTION \
+	    -v $(ARTIFACTS_DIR):/dist \
+	    $(BUILDIMAGE)
+
+docker-clean:
+	IMAGES=$$(docker images "nvidia/$(LIB_NAME)/*" --format="{{.ID}}"); \
+	if [ "$${IMAGES}" != "" ]; then \
+	    docker rmi -f $${IMAGES}; \
+	fi
+
+distclean:
+	rm -rf $(DIST_DIR)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 This is a demostration of the integration of [AutowareAI](https://gitlab.com/autowarefoundation/autoware.ai) and the [CARLA](https://carla.org/) simulator. 
 
 # Installing requirements
-* This demo works on Ubuntu 18.04 with CUDA 10.2 (you need an NVIDIA graphics card).
+* This demo works on most Linux distributions with CUDA installed (you need an NVIDIA graphics card).
 * Install NVIDIA drivers and verify the drivers with: `nvidia-smi`
-* Install Docker: `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/ubuntu/bionic/install-docker.sh | bash`
-* Install the NVIDIA Container Toolkit: `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/nvidia/docker/install-nvidia-docker.sh | bash`
-* Install [ADE](https://www.apex.ai/post/ade-ensuring-that-all-developers-in-a-project-have-a-common-consistent-development-environment): `curl -fsSL https://gitlab.com/nubonetics-ade/utilities/-/raw/master/development/install-ade.sh | bash`
+* This demo requires Docker, NVIDIA Container Toolkit, and [ADE](https://www.apex.ai/post/ade-ensuring-that-all-developers-in-a-project-have-a-common-consistent-development-environment) to be installed. 
+* For a local installation of the requirements run: `bash install_dependencies.sh` after you have cloned this repository. (see [Getting Started](#getting-started) for more information)
+* To remove the installed binaries and the docker images run: `bash remove_dependencies.sh`
 
 # Getting Started
 * Create your workspace directory (you can choose your own name or use an existing folder): `mkdir adehome`
@@ -14,6 +14,7 @@ This is a demostration of the integration of [AutowareAI](https://gitlab.com/aut
 * Create an empty .adehome file: `touch .adehome`
 * Clone this repository: `git clone https://github.com/eLearningHub/AutowareAI-CARLA.git`
 * Enter the clone directory: `cd AutowareAI-CARLA`
+* Here you can choose to install the dependencies with the `bash install_dependencies.sh` (requires `make` package and root privileges)
 * Run ADE: `ade start --enter`
 * Inside ADE, go to the clone directory: `cd AutowareAI-CARLA`
 * Inside ADE, run Carla: `source run-carla.sh`

--- a/bin_files
+++ b/bin_files
@@ -1,0 +1,9 @@
+ade
+containerd-shim
+docker
+docker-init
+runc
+containerd
+ctr
+dockerd
+docker-proxy

--- a/daemon_check.py
+++ b/daemon_check.py
@@ -1,0 +1,17 @@
+import json
+from json.decoder import JSONDecodeError
+
+def main():
+    path = "/etc/docker/daemon.json"
+    with open(path, "r") as json_file:
+        try:
+            json_data = json.loads(json_file.read())
+            json_data.update({"experimental":True})
+        except JSONDecodeError:
+            json_data = {"experimental":True}
+
+    with open(path, "w") as json_file:
+        json.dump(json_data, json_file, sort_keys=True)
+
+if __name__ == "__main__":
+    main()

--- a/docker_containers
+++ b/docker_containers
@@ -1,0 +1,4 @@
+ade
+ade_registry.gitlab.com_nubodev_vscode_1.44
+ade_registry.gitlab.com_nubodev_carla_latest
+ade_registry.gitlab.com_nubodev_autowareai_latest

--- a/docker_images
+++ b/docker_images
@@ -1,0 +1,6 @@
+nvidia/nvidia-docker2/ubuntu18.04-amd64:latest
+ubuntu:18.04
+registry.gitlab.com/nubodev/ade:melodic-cuda
+registry.gitlab.com/nubodev/autowareai:latest
+registry.gitlab.com/nubodev/carla:latest
+registry.gitlab.com/nubodev/vscode:1.44

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+if [ ! -f /usr/bin/docker ]; then
+        wget https://download.docker.com/linux/static/stable/x86_64/docker-19.03.9.tgz
+        tar xzvf docker-19.03.9.tgz && rm docker-19.03.9.tgz
+        sudo mv docker/* /usr/local/bin
+        rm -r docker/
+fi;
+
+sudo mkdir -p /etc/docker/
+
+if [ ! -f /etc/docker/daemon.json ]; then
+        sudo touch /etc/docker/daemon.json
+fi;
+
+sudo python3 daemon_check.py
+sleep 2
+sudo dockerd &
+sleep 3
+sudo chmod 666 /var/run/docker.sock
+
+git clone https://github.com/NVIDIA/nvidia-docker.git
+cp -r Makefile nvidia-docker/
+cd nvidia-docker
+make
+cd ..
+
+if [ ! -f /usr/bin/ade ]; then
+        wget https://gitlab.com/ApexAI/ade-cli/-/jobs/1341322851/artifacts/raw/dist/ade+x86_64
+        mv ade+x86_64 ade
+        sudo chmod +x ade
+        sudo mv ade /usr/local/bin
+fi;

--- a/remove_dependencies.sh
+++ b/remove_dependencies.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+for container in $(cat docker_containers)
+do
+	docker kill $container
+	docker rm $container
+done
+
+for image in $(cat docker_images)
+do
+	docker rmi $image
+done
+
+sudo pkill docker
+
+for file in $(cat bin_files)
+do
+	sudo rm /usr/local/bin/$file
+done
+
+sudo rm -rf nvidia-docker


### PR DESCRIPTION
As an Archlinux user, I wanted this demo to be accessible to more people, so I created a few scripts to locally install the dependencies without relying on the built-in package manager. Now there is also a script to revert **_most_** system-level changes as well. I tested the scripts on an Ubuntu and a Fedora VM, and they finish successfully. However, my VM software does not support GPU Passthrough, so I could not test the actual demo. Please review and let me know what you think!